### PR TITLE
Messageモデル作成

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,6 @@
 class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
+  has_many :messages
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,2 +1,6 @@
 class Message < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+
+  validates :content, presence: true, unless: :image?
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,2 @@
+class Message < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-
   has_many :messages
   has_many :group_users
   has_many :groups, through: :group_users

--- a/db/migrate/20190914090439_create_messages.rb
+++ b/db/migrate/20190914090439_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+      t.string :content
+      t.string :image
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190908083222) do
+ActiveRecord::Schema.define(version: 20190914090439) do
 
   create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "group_id"
@@ -25,6 +25,17 @@ ActiveRecord::Schema.define(version: 20190908083222) do
     t.string   "name",       null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "content"
+    t.string   "image"
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -43,4 +54,6 @@ ActiveRecord::Schema.define(version: 20190908083222) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
group_idとuser_idはreferences型で設定してあるので、カラム名に_idは不要。
その2つのカラムには外部キー制約をつける。
なお、referencesを使用するとインデックスの設定も自動的に行われる。

モデルの作成後は、モデル間のアソシエーションを定義しておく。