### PR TITLE
メッセージ送信機能実装

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,5 +1,29 @@
 class MessagesController < ApplicationController
+  before_action :set_group
+
   def index
-    render "messages/index"
+    @message = Message.new
+    @messages = @group.messages.includes(:user)
+  end
+
+  def create
+    @message = @group.messages.new(message_params)
+    if @message.save
+      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+    else
+      @messages = @group.messages.includes(:user)
+      flash.now[:alert] = 'メッセージを入力してください。'
+      render :index
+    end
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
   end
 end

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -47,10 +47,10 @@
           .lower-message__content
             メッセージ
     .form
-      %form
-        %input.form__message
+      = form_for [@group, @message] do |f|
+        = f.text_field :content, class: 'form__message', placeholder: 'type a message'
         .form__mask
-          %label.form__mask__image
+          = f.label :image, class: 'form__mask__image' do
             = fa_icon 'picture-o', class: 'icon'
-            %input.hidden{type: 'file'}
-        %input.form__submit{type: 'submit', value: 'Send'}
+            = f.file_field :image, class: 'hidden'
+        = f.submit 'Send', class: 'form__submit'


### PR DESCRIPTION
まずは、messagesコントローラの記述を行っていきましょう。必要となるアクションはindexとcreateの2つです。

private以下にset_groupを定義し、before_actionを利用して呼び出すことで、messagesコントローラの全てのアクションで@groupを利用できるようになります。

indexアクションでは、Messageモデルの新しいインスタンスである@message、グループに所属する全てのメッセージである@messagesを定義しています。「n + 1 問題」を避けるために、includes(:user)の記述を忘れずに行いましょう。

createアクションでは、グループ作成機能を実装した際と同様に、保存に成功した場合、保存に失敗した場合で処理を分岐させましょう。

続いて、メッセージを保存できるように、ビューを編集しましょう。formタグ、inputタグを用いて記述されている箇所をform_forを使って書き換えていきます。

form_forの引数に@group, @messageの2つを渡している点に注意してください。通常、messagesのcreateアクションは、messages_pathにPOSTメソッドでリクエストを送った際に実行されます。

しかしながら、今回の場合、messagesはgroupsにネストされているため、createアクションのパスはgroup_messages_pathに変化しています。「form_for @message」と記述したのみでは、messages_pathにリクエストを送ってしまうため、レコードを保存することができません。

「form_for [@group, @message]」と記述することで、group_messages_pathにリクエストを送ることができます。このように、ネストされたモデルに対してform_forを使用する場合、親モデルのインスタンス(もしくは親モデルのid)を第1引数、子モデルのインスタンスを第2引数に設定する必要があります。